### PR TITLE
「Eloquent・クエリビルダ」リレーション実装目的を変更

### DIFF
--- a/source/_posts/2022-07-17-laravel-coding-guideline.md
+++ b/source/_posts/2022-07-17-laravel-coding-guideline.md
@@ -132,7 +132,6 @@ Eloquentのデメリットとして一般的に次のようなものが挙げら
 * 外部ツール
   * モデルへの `@property` アノテーションの付与によるコード補完
   * 同じく静的解析
-  * [Laravel ER Diagram Generator](https://github.com/beyondcode/laravel-er-diagram-generator) 等によるER図の自動生成
 
 {% enddetails %}
 

--- a/source/_posts/2022-07-17-laravel-coding-guideline.md
+++ b/source/_posts/2022-07-17-laravel-coding-guideline.md
@@ -129,6 +129,7 @@ Eloquentのデメリットとして一般的に次のようなものが挙げら
 * Eloquent外から利用できる機能
   * [モデル結合ルート](https://laravel.com/docs/9.x/routing#route-model-binding)
   * [ポリシー](https://laravel.com/docs/9.x/authorization#creating-policies)
+  * [model:show コマンド](https://github.com/laravel/framework/pull/43156) 等によるメタデータの生成<!-- TODO マニュアルに掲載次第URLを変更-->
 * 外部ツール
   * モデルへの `@property` アノテーションの付与によるコード補完
   * 同じく静的解析


### PR DESCRIPTION
* Laravel ER Diagram Generator の記載を削除  
  最新バージョンのLaravel, PHPに対応していない
* `./artisan model:show` コマンドをサンプルに明記  
  TODO: まだマニュアルに掲載されていないため掲載次第リンク先を変更する
